### PR TITLE
Support TST 3.0.12 and later

### DIFF
--- a/background.js
+++ b/background.js
@@ -150,10 +150,11 @@ browser.runtime.onMessageExternal.addListener((message, sender) => {
       if (message.closebox || message.soundButton || message.twisty) {
         break;
       }
-      if (settings.preventOnlyForUnloadedTabs && !message.tab.discarded) {
-        break;
-      }
-      const aPromise = new Promise((resolve, reject) => {
+      const aPromise = new Promise(async (resolve, reject) => {
+        const tab = await browser.tabs.get(message.tab.id);
+        if (settings.preventOnlyForUnloadedTabs && !tab.discarded) {
+          return resolve(false);
+        }
         resolveAs(true);
         lastResolve = (value) => {
           if (value) {


### PR DESCRIPTION
On TST 3.0.12 and later, `tab` and `tabs` delivered via its API won't have `tabs.Tab` compatible properties by default, due to security reasons. I think that these changes should make this addon compatible to TST 3.0.12 and later.

For more details, please see the updated API document:
https://github.com/piroor/treestyletab/wiki/API-for-other-addons#information-in-private-windows
https://github.com/piroor/treestyletab/wiki/API-for-other-addons#extra-permissions
https://github.com/piroor/treestyletab/wiki/API-for-other-addons#data-format
https://github.com/piroor/treestyletab/wiki/API-for-other-addons#when-permissions-for-your-addon-are-changed
